### PR TITLE
fall back to local file system path if dependency is not a git url

### DIFF
--- a/cmds/install/index.js
+++ b/cmds/install/index.js
@@ -43,7 +43,13 @@ function install(options) {
       downloads.push(function(callback) {
         addRemoteGit.download(value, function(err, download) {
           if (err) {
-            return callback(err)
+            console.log("NOT A GIT URL - assuming file system path")
+            console.log(value)
+            console.log(key)
+            download = {}
+            download.tmpdir = value
+            download.sourceKey = key
+            return callback(null, download)
           }
           download.sourceValue = value
           download.sourceKey = key


### PR DESCRIPTION
Might be better to modify the `add-remote-git` dependency to support various link types, but this was a nice simple work-around. Mostly submitting this PR to get you to think about it and see what you want to do.

The motivation is that during development of the module, the only current way to test is to continually push your (potentially untested) changes to the module repository so that the consuming app can pull in the changes.