### PR TITLE
Added temporary files modifiers option

### DIFF
--- a/cmds/pack/index.js
+++ b/cmds/pack/index.js
@@ -19,6 +19,7 @@ function pack(options) {
   var cwd = _.get(options, 'cwd')
   var debug = !!(_.get(options, 'debug'))
   var ignore = _.get(options, 'ignore') || []
+  var modifiers = _.get(options, 'modifiers') || []
   var logger = new Logger(debug)
   var tmpDir = utils.tmpDir
   var rokuModulesPath
@@ -43,6 +44,10 @@ function pack(options) {
         return true
       }
     })
+  }).then(async function() {
+    for (const modifier of modifiers) {
+      await modifier(tmpDir)
+    }
   }).then(function() {
     rokuModulesPath = path.join(tmpDir, 'roku_modules')
 


### PR DESCRIPTION
Thanks to this change it's easy to add any JS scripts that may modify temporary files, e.g. "transpilers" of custom annotations. They may return a Promise (because operations on files are async), so an array of modifiers scripts is iterated synchronously using a combination of async-await and for-of loop.